### PR TITLE
Change dev scripts

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "_comment": "we don't have a src folder right now, and until we make that, these scripts won't work.",
     "start": "node ./src/bin/www",
-    "dev": "PORT=3001 dotenv nodemon ./src/bin/www --watch src --ignore src/logs"
+    "dev-lin": "PORT=3001 dotenv nodemon ./src/bin/www --watch src --ignore src/logs",
+    "dev-win": "SET PORT=3001 dotenv nodemon ./src/bin/www --watch src --ignore src/logs"
   },
   "dependencies": {
     "cookie-parser": "~1.4.3",


### PR DESCRIPTION
Since "SET" is needed for windows, we added a separate dev script for them.

To run on windows: `npm run-script dev-win`
To run on Linux/Mac: `npm run-script dev-lin`