### PR TITLE
Add Account Payment Page Template

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5588,7 +5588,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5953,7 +5954,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6001,6 +6003,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6039,11 +6042,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/client/src/components/PaymentPageContent.js
+++ b/client/src/components/PaymentPageContent.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+/**
+ * Container for payment page content. Each page's content will be different, but switched here.
+ */
+class PaymentPageContent extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  // currently printing out the current page number.
+  // TODO: Add logic to switch between content of different pages
+  // TODO: Add styling
+  render() {
+  return (
+    <div>
+      <h3>{this.props.currentPage}</h3>
+    </div>
+    );
+  }
+}
+
+export default PaymentPageContent;

--- a/client/src/components/PaymentProgress.js
+++ b/client/src/components/PaymentProgress.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+/**
+ * The bubbles o(≧∇≦o) that show the user how many of the pages they have completed.
+ */
+class PaymentProgress extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  // Currently printing out the current page number.
+  // TODO: Add logic to switch between the of different pages
+  // TODO: Add styling
+  render() {
+    return (
+      <div>
+        <h1>{this.props.currentPage}</h1>
+      </div>
+    );
+  }
+}
+
+export default PaymentProgress;

--- a/client/src/pages/PaymentPage.js
+++ b/client/src/pages/PaymentPage.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+
+import PaymentPageContent from '../components/PaymentPageContent';
+import PaymentPageProgress from '../components/PaymentPageContent'; // TODO: make a class that will export all these
+
+/**
+ * Parent class for Payment Page. Contains the text "Account Payment", then the progress bar through the pages, and a
+ * placeholder for the current PaymentPageContent.
+ */
+class PaymentPage extends Component {
+
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+        currentPage: 0 // will be used to determine what page to float to UI (might change to Enum)
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Account Payment</h2>
+        <PaymentPageProgress currentPage={this.state.currentPage} />
+        <PaymentPageContent currentPage={this.state.currentPage} />
+      </div>
+    );
+  }
+}
+
+export default PaymentPage;


### PR DESCRIPTION
Adding templates for the account payment page we discussed.

PaymentPage.js contains the top level common components. Right now that is a text field with "Account Payment", followed by the progress bar (not yet implemented) in PaymentProgress.js.
PaymentPageContent.js is where all that page's specific content goes into.

Edit:
Preview of the screen right now!

<img width="1436" alt="screen shot 2019-02-08 at 6 46 14 pm" src="https://user-images.githubusercontent.com/10266078/52512653-047ef100-2bd4-11e9-8aef-ca9c87a23450.png">