### PR TITLE
Add Progressbar

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6276,9 +6276,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
       "requires": {
         "async": "^2.5.0",
         "optimist": "^0.6.1",
@@ -13426,6 +13426,16 @@
         "webpack-dev-server": "3.1.14",
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "3.6.3"
+      }
+    },
+    "react-step-progress-bar": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-step-progress-bar/-/react-step-progress-bar-1.0.3.tgz",
+      "integrity": "sha512-h9ZMopLZWLdf7zejXikH5J9+0yaWvYdz63sITi+x1+N4uparmrUH0EpAmaRpGqBYv7nC08IPTAUwH8h1VVRe0g==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "invariant": "^2.2.4",
+        "react-transition-group": "^2.4.0"
       }
     },
     "react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "react-bootstrap": "^1.0.0-beta.5",
     "react-dom": "^16.8.1",
     "react-scripts": "2.1.3",
+    "react-step-progress-bar": "^1.0.3",
     "reactstrap": "^7.1.0"
   },
   "scripts": {

--- a/client/src/components/PaymentPageProgress.js
+++ b/client/src/components/PaymentPageProgress.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import 'react-step-progress-bar/styles.css';
+import { ProgressBar, Step } from 'react-step-progress-bar';
 
 /**
  * The bubbles o(≧∇≦o) that show the user how many of the pages they have completed.
@@ -6,6 +8,39 @@ import React, { Component } from 'react';
 class PaymentPageProgress extends Component {
   constructor(props) {
     super(props);
+    
+    this.progressPercentage = this.progressPercentage.bind(this);
+    this.makeSteps = this.makeSteps.bind(this);
+
+    this.state = {
+      currentPage: this.props.currentPage,  // We will be starting from page 1 to Nth page.
+      numPages: this.props.numPages
+    }
+  }
+
+  /**
+   * Calculates the current percent that the bar has completed.
+   */
+  progressPercentage() {
+    return ((this.props.currentPage - 1.0)/(this.props.numPages - 1.0)) * 100.0; // Mathematics magic
+  }
+
+  /**
+   * Makes the numbers (1 to the number of pages) above the progress bar so the user
+   * can see their progress with the number of pages.
+   */
+  makeSteps() {
+    var steps = [...Array(this.state.numPages + 1)].map((_,i) => i); // creating an array from 0 to num pages
+    steps.shift();  // removing first index since we want an array from 1 to num pages
+    return steps.map(function(d, id) {
+      return (
+        <Step transition="scale" index={d}>
+          {({ accomplished }) => (
+            <p>{d}</p>
+          )}
+        </Step>
+      );
+    })
   }
 
   // Currently printing out the current page number.
@@ -13,9 +48,12 @@ class PaymentPageProgress extends Component {
   // TODO: Add styling
   render() {
     return (
-      <div>
-        <h1>{this.props.currentPage}</h1>
-      </div>
+      <ProgressBar
+        percent={this.progressPercentage()}
+        filledBackground="linear-gradient(to right, #66BB6A, #66BB6A)"
+      >
+        {this.makeSteps()}
+      </ProgressBar>
     );
   }
 }

--- a/client/src/pages/PaymentPage.js
+++ b/client/src/pages/PaymentPage.js
@@ -13,7 +13,8 @@ class PaymentPage extends Component {
     super(props);
     
     this.state = {
-        currentPage: 0 // will be used to determine what page to float to UI (might change to Enum)
+        currentPage: 1, // will be used to determine what page user is on. We start at page 1, end on numPages
+        numPages: 4
     }
   }
 
@@ -21,7 +22,7 @@ class PaymentPage extends Component {
     return (
       <div>
         <h2>Account Payment</h2>
-        <PaymentPageProgress currentPage={this.state.currentPage} />
+        <PaymentPageProgress currentPage={this.state.currentPage} numPages={this.state.numPages}/>
         <PaymentPageContent currentPage={this.state.currentPage} />
       </div>
     );


### PR DESCRIPTION
Made an extensible progress bar that will change depending on the number of pages and the current page we're on!

Mockups:

<img width="864" alt="screen_shot_2019-02-05_at_8 00 27_pm" src="https://user-images.githubusercontent.com/10266078/52890822-d6aa2700-3154-11e9-8c78-c780af14394c.png">
<img width="863" alt="screen_shot_2019-02-05_at_8 01 49_pm" src="https://user-images.githubusercontent.com/10266078/52890823-d742bd80-3154-11e9-806d-0d852a3eec2d.png">


Built it for our 4 page design, this is what it'd look like when the user is on the first page:

![screen shot 2019-02-15 at 7 02 02 pm](https://user-images.githubusercontent.com/10266078/52890803-b4180e00-3154-11e9-9b1c-feeaaffe0ca0.png)

Second Page:

![screen shot 2019-02-15 at 7 02 16 pm](https://user-images.githubusercontent.com/10266078/52890809-c09c6680-3154-11e9-9294-a7f78dbb77fb.png)

Last Page:

![screen shot 2019-02-15 at 7 02 28 pm](https://user-images.githubusercontent.com/10266078/52890816-cc882880-3154-11e9-9906-a783474da4ed.png)
