### PR TITLE
Fix Heroku (rm jest-cli)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "fsevents": "^1.2.7",
-    "jest-cli": "^24.1.0",
     "jquery": "^1.9.1",
     "react": "^16.8.1",
     "react-bootstrap": "^1.0.0-beta.5",


### PR DESCRIPTION
Fixed Heroku deployment issue (?) by removing double dependency of jest-cli for client.