### PR TITLE
Add Page 2 Styling

### DIFF
--- a/client/src/components/PayPalConnect.js
+++ b/client/src/components/PayPalConnect.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import Button from 'react-bootstrap/Button'
+import Button from 'react-bootstrap/Button';
+import './css/PayPalConnect.css'
 
 /**
  * This is the PayPal connection component for the second page of the account payment portal.
@@ -35,14 +36,21 @@ class PayPalConnect extends Component {
      */
     render() {
         return (
-            <div>
-                <div>
+            <div className="center">
+                <div className="left">
                     <span>
                         <p>Total Fee: </p> {"$" + this.state.totalFee}
                     </span>
-                    <p>Tax: </p> {"$" + this.state.tax}
-                    <h5>Payment Total: </h5> {"$" + this.state.paymentTotal}
+                    <br/>
+                    <span>
+                        <p>Tax: </p> {"$" + this.state.tax}
+                    </span>
+                    <br/>
+                    <span>
+                        <h5>Payment Total: </h5> {"$" + this.state.paymentTotal}
+                    </span>
                 </div>
+                <br/>
                 <Button
                     variant="primary"
                     as="input"

--- a/client/src/components/css/PayPalConnect.css
+++ b/client/src/components/css/PayPalConnect.css
@@ -1,0 +1,16 @@
+.center {
+  margin: auto;
+  width: 80%;
+  padding: 10px;
+  text-align: center;
+}
+
+span p, h5 {
+  display: inline-block;
+}
+
+.left {
+  text-align: left;
+  display: inline-block;
+  margin-bottom: 15px;
+}


### PR DESCRIPTION
Added styling for page 2 of the payment portal.

Implemented:
<img width="1440" alt="screen shot 2019-03-04 at 3 04 47 pm" src="https://user-images.githubusercontent.com/10266078/53759692-efbe1200-3e8e-11e9-9f5e-b8838a990cef.png">

Mockup:

<img width="863" alt="screen_shot_2019-02-05_at_8 01 49_pm" src="https://user-images.githubusercontent.com/10266078/53759725-02d0e200-3e8f-11e9-858f-6a90ff40b58e.png">
