### PR TITLE
Add Styling for Page 4

### DIFF
--- a/client/src/components/Receipt.js
+++ b/client/src/components/Receipt.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import logoImage from './../images';
 import ChargesList from './ChargesList';
-import './css/PaymentContent.css';
+import './css/Receipt.css';
 
 /**
  * Parent class for Receipt Page. Contains labels and placeholder data to be retrieved by the API.
@@ -15,10 +15,12 @@ class Receipt extends Component {
         activities: [],
         paymentInfo: {}
     }
+
+    this.onClickGetPDF = this.onClickGetPDF.bind(this);
   }
 
   componentDidMount() {
-    // activities, total, and payment info are placeholders, to be replaced with an API call
+    // TODO: activities, total, and payment info are placeholders, to be replaced with an API call
     const activities = [{name:"Activity Fee", price:"400"}, {name:"Uniform Fee", price:"40"}, {name:"Transportation Fee", price:"40"}, {name:"Textbook Fee", price:"40"}];
     const paymentInfo = {
       billFromName:"Bright Futures Academy", 
@@ -39,47 +41,57 @@ class Receipt extends Component {
   render() {
     const { activities, paymentInfo } = this.state;
     return (
-      <div>
-        <h4>Receipt</h4>
-        <img src={logoImage} height="300" alt="Bright Futures Academy Logo"/>
+      <div className="receipt">
+        <div className="border">
+          <h4>Receipt</h4>
 
-        <div>
-          <p>Bill From: 
-          <br /> {paymentInfo.billFromName}
-          <br /> {paymentInfo.billFromAddressLine1}
-          <br /> {paymentInfo.billFromAddressLine2} 
-          <br />
-          <br />Bill To:
-          <br /> {paymentInfo.billToName}
-          <br /> {paymentInfo.billToAddressLine1}
-          <br /> {paymentInfo.billToAddressLine2}
-          <br />
-          <br />Invoice Number #: {paymentInfo.invoiceNum}
-          <br />Invoice Date: {paymentInfo.invoiceDate}
-          <br />Amount Due: {"$" + paymentInfo.total}
-          </p>
+          <div className="address">
+            <span>
+              <img id="brightFuturesLogo" className="rightWithFloat" src={logoImage} height="150" alt="Bright Futures Academy Logo"/>
+              <div className="leftWithFloat">
+                Bill From: 
+                <br /> {paymentInfo.billFromName}
+                <br /> {paymentInfo.billFromAddressLine1}
+                <br /> {paymentInfo.billFromAddressLine2} 
+              </div>
+            </span>
+          </div>
+          <div className="address">
+            <span>
+              <div className="leftWithFloat">
+              Bill To:
+                <br /> {paymentInfo.billToName}
+                <br /> {paymentInfo.billToAddressLine1}
+                <br /> {paymentInfo.billToAddressLine2}
+              </div>
+              <div className="rightWithFloat">
+                <br />Invoice Number #: {paymentInfo.invoiceNum}
+                <br />Invoice Date: {paymentInfo.invoiceDate}
+                <br /> <p className="blueBackground">Amount Due: {"$" + paymentInfo.total}</p>
+              </div>
+            </span>
+          </div>
+
+          <div className="chargesList">
+            <ChargesList activities={activities}/>
+          </div>
+          <div className="rightWithFloat wrap">
+            <p>Subtotal: {paymentInfo.subtotal}
+            <br />Tax: {paymentInfo.tax}
+            <br /><p className="blueBackground">Total: {paymentInfo.total}</p>
+            </p>
+          </div>
         </div>
-       
-        <br />
-        <ChargesList activities={activities}/>
-        <br />
-
-        <div>
-          <p>Subtotal: {paymentInfo.subtotal}
-          <br />Tax: {paymentInfo.tax}
-          <br />Total: {paymentInfo.total}
-          </p>
-        </div>  
-        
-        <form onSubmit={this.onClickGetPDF}>
+          <form onSubmit={this.onClickGetPDF} className="center">
           <input type="submit" value="Download PDF" />
-        </form>
+          </form>
       </div>
     );
   }
 
   onClickGetPDF() {
       // TODO: allow information on page to be downloaded as pdf
+      alert("Get pdf of Receipt");
   }
 }
 

--- a/client/src/components/css/Receipt.css
+++ b/client/src/components/css/Receipt.css
@@ -1,0 +1,62 @@
+.receipt {
+    width: 80%;
+
+}
+
+.border {
+    border: 5px solid black;
+    width: 100%;
+    padding: 2%;
+    overflow: hidden;
+}
+
+div > div > span {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+}
+
+.address {
+    padding-left: 3%;
+}
+
+.leftWithFloat {
+    float: left;
+    text-align: left;
+}
+
+.rightWithFloat {
+    float: right;
+    text-align: right;
+}
+
+#brightFuturesLogo {
+    padding-right: 5%;
+}
+
+.blueBackground {
+    background-color: #95BCF2
+}
+
+.left {
+    text-align: left;
+}
+
+.right {
+    text-align: right;
+}
+
+.center {
+    text-align: center
+}
+
+.chargesList {
+    width: 50%;
+    margin: 0 auto;
+    padding: 10px;
+    justify-content: center;
+}
+
+.rightWithFloat.wrap {
+    display: inline-flex;
+}


### PR DESCRIPTION
Added styling for page 4 of the payment portal. Couldn't quite get the Receipt in the border, and the table is currently ChargesList, which is different. We may want to make another component to get it to look like the mockup.

Implementation:
<img width="941" alt="screen shot 2019-03-04 at 4 30 45 pm" src="https://user-images.githubusercontent.com/10266078/53764342-fc486780-3e9a-11e9-9e45-9c195db16eff.png">

Mockup:
<img width="862" alt="screen_shot_2019-02-17_at_5 19 18_pm" src="https://user-images.githubusercontent.com/10266078/53764350-023e4880-3e9b-11e9-967f-b8216a7dbe1e.png">
