### PR TITLE
Hotfix server ports

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -53,8 +53,8 @@ mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true }).then(() => 
  });
  
  // Start server to serve endpoints
- console.log('Express started. Listening on port', process.env.SERVER_PORT || 5000);
- app.listen(process.env.SERVER_PORT || 5000);
+ console.log('Express started. Listening on port', process.env.PORT || 5000);
+ app.listen(process.env.PORT || 5000);
 
 // Render React page (keep this at the bottom of the file)
 app.use(express.static(path.join(__dirname, "../client/build/")));

--- a/server/bin/www
+++ b/server/bin/www
@@ -12,8 +12,8 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.CLIENT_PORT || '3000');
-app.set('port', port);
+// var port = normalizePort(process.env.PORT || '3000');
+// app.set('port', port);
 
 /**
  * Create HTTP server.
@@ -25,7 +25,7 @@ var server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+// server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
 


### PR DESCRIPTION
Removing port usages in www because we're already covering that in app.js. Prioritize app.js over www. Turns out that Heroku dynamically chooses the ports you use, so defining client_port and server_port is improper.

https://stackoverflow.com/questions/28318217/port-34037-is-already-in-use-heroku-nodejs-express-websockets