### PR TITLE
Add landing page spotlight

### DIFF
--- a/client/src/components/Spotlight.js
+++ b/client/src/components/Spotlight.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import logoImage from './../images'
+import './css/Spotlight.css';
+
+/**
+ * Spotlight/Impact component.
+ */
+class Spotlight extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+          currentTab: 0
+        }
+        this.onClickItem = this.onClickItem.bind(this);
+    }
+
+    onClickItem(position) {
+        // TODO: Show detailed information about chosen icon
+        alert("See more information about feature " + position);
+    }
+
+    render() {
+        // const { teachers } = this.state;
+        // how to programmatically change display of text bw none/flex
+        return (
+          <div className="card-container">
+            <div className="titles-container">
+              <div className="text-underline-container">
+                <p className="title-text"> Spotlight </p>
+                <div className="spotlight-underline"/>
+              </div>
+              <div className="text-underline-container">
+                <p className="title-text"> Impact </p>
+                <div className="impact-underline"/>
+              </div>
+            </div>
+            <div className="spotlight-features-container">
+              <div className="feature" onClick={this.onClickItem}>
+              {/* TODO: figure out how to pass params (0, 1, 2, representing item position) */}
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">The Arts</p>
+              </div>
+              <div className="feature">
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">Diversity</p>
+              </div>
+              <div className="feature">
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">Free Expression</p>
+              </div>
+            </div>
+
+            <div className="impact-features-container">
+              <div className="feature">
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">PreK-12</p>
+              </div>
+              <div className="feature">
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">Urban</p>
+              </div>
+              <div className="feature">
+                <img alt="#" src={logoImage[0]} className="feature-image"/>
+                <p className="feature-text">Innovation</p>
+              </div>
+            </div>
+          </div>
+        );
+    }
+}
+
+export default Spotlight;

--- a/client/src/components/Spotlight.js
+++ b/client/src/components/Spotlight.js
@@ -10,10 +10,15 @@ class Spotlight extends Component {
     constructor(props) {
         super(props);
         this.state = {
-          currentTab: 0
+          currentTab: 0,
+          spotlightStyle: "hidden", 
+          impactStyle: "hidden", 
+          spotlightContainer: "hidden", 
+          impactContainer: "hidden"
         }
         this.onClickItem = this.onClickItem.bind(this);
         this.setTab = this.setTab.bind(this);
+        this.setStyles = this.setStyles.bind(this);
     }
 
     onClickItem(position) {
@@ -25,21 +30,28 @@ class Spotlight extends Component {
       this.setState({currentTab: tab});
     }
 
-    render() {
-        const { currentTab } = this.state;
+    setStyles() {
+      var {currentTab, spotlightStyle, impactStyle, spotlightContainer, impactContainer} = this.state;
+      if (currentTab === 0) {
+        spotlightStyle = "spotlight-underline";
+        impactStyle = "hidden";
+        spotlightContainer = "spotlight-features-container";
+        impactContainer = "hidden";
+      } else if (currentTab === 1) {
+        spotlightStyle = "hidden";
+        impactStyle = "impact-underline";
+        spotlightContainer = "hidden";
+        impactContainer = "impact-features-container";
+      } 
+      return [spotlightStyle, impactStyle, spotlightContainer, impactContainer];
+    }
 
-        var spotlightStyle, impactStyle, spotlightContainer, impactContainer = "hidden";
-        if (currentTab === 0) {
-          spotlightStyle = "spotlight-underline";
-          impactStyle = "hidden";
-          spotlightContainer = "spotlight-features-container";
-          impactContainer = "hidden";
-        } else if (currentTab === 1) {
-          spotlightStyle = "hidden";
-          impactStyle = "impact-underline";
-          spotlightContainer = "hidden";
-          impactContainer = "impact-features-container";
-        }
+    render() {
+        var styles = this.setStyles();
+        var spotlightStyle = styles[0];
+        var impactStyle = styles[1];
+        var spotlightContainer = styles[2];
+        var impactContainer = styles[3];
 
         return (
           <div className="card-container">

--- a/client/src/components/Spotlight.js
+++ b/client/src/components/Spotlight.js
@@ -13,6 +13,7 @@ class Spotlight extends Component {
           currentTab: 0
         }
         this.onClickItem = this.onClickItem.bind(this);
+        this.setTab = this.setTab.bind(this);
     }
 
     onClickItem(position) {
@@ -20,47 +21,64 @@ class Spotlight extends Component {
         alert("See more information about feature " + position);
     }
 
+    setTab(tab) {
+      this.setState({currentTab: tab});
+    }
+
     render() {
-        // const { teachers } = this.state;
-        // how to programmatically change display of text bw none/flex
+        const { currentTab } = this.state;
+
+        var spotlightStyle, impactStyle, spotlightContainer, impactContainer = "hidden";
+        if (currentTab === 0) {
+          spotlightStyle = "spotlight-underline";
+          impactStyle = "hidden";
+          spotlightContainer = "spotlight-features-container";
+          impactContainer = "hidden";
+        } else if (currentTab === 1) {
+          spotlightStyle = "hidden";
+          impactStyle = "impact-underline";
+          spotlightContainer = "hidden";
+          impactContainer = "impact-features-container";
+        }
+
         return (
           <div className="card-container">
             <div className="titles-container">
               <div className="text-underline-container">
-                <p className="title-text"> Spotlight </p>
-                <div className="spotlight-underline"/>
+                <p className="title-text" onClick={() => this.setTab(0)} > Spotlight </p>
+                <div className={spotlightStyle}/>
               </div>
               <div className="text-underline-container">
-                <p className="title-text"> Impact </p>
-                <div className="impact-underline"/>
+                <p className="title-text" onClick={() => this.setTab(1)} > Impact </p>
+                <div className={impactStyle}/>
               </div>
             </div>
-            <div className="spotlight-features-container">
-              <div className="feature" onClick={this.onClickItem}>
-              {/* TODO: figure out how to pass params (0, 1, 2, representing item position) */}
+
+            <div className={spotlightContainer}>
+              <div className="feature" onClick={() => this.onClickItem(0)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">The Arts</p>
               </div>
-              <div className="feature">
+              <div className="feature" onClick={() => this.onClickItem(1)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">Diversity</p>
               </div>
-              <div className="feature">
+              <div className="feature" onClick={() => this.onClickItem(2)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">Free Expression</p>
               </div>
             </div>
 
-            <div className="impact-features-container">
-              <div className="feature">
+            <div className={impactContainer}>
+              <div className="feature" onClick={() => this.onClickItem(0)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">PreK-12</p>
               </div>
-              <div className="feature">
+              <div className="feature" onClick={() => this.onClickItem(1)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">Urban</p>
               </div>
-              <div className="feature">
+              <div className="feature" onClick={() => this.onClickItem(2)} >
                 <img alt="#" src={logoImage[0]} className="feature-image"/>
                 <p className="feature-text">Innovation</p>
               </div>

--- a/client/src/components/css/AboutUs.css
+++ b/client/src/components/css/AboutUs.css
@@ -1,6 +1,6 @@
 .rectangleImageAbout {
-    width: 600px;
-    height: 350px;
+    width: 100%;
+    height: 300px;
     border: solid 1px #979797;
     background-color: #d8d8d8;
 }
@@ -9,27 +9,20 @@
     height: 50%;
     border: solid 1px #979797;
     background-color: #222222;
-    margin:auto;
+    /* margin:auto; */
     overflow:hidden;
     text-align:center;
     width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    padding: 10%;
+    padding-top: 5%;
+    padding-bottom: 5%;
 }
 
 .left {
-    float: left;
-}
-
-.right {
-    float: right;
-}
-
-.rectangleBackgroundAbout > div {
-    margin: 2%;
-    padding: 20px;
-    max-width: 40%; /* because margin is 2%, we have 2 divs, so (100% - 2*2%)/2 = 46% */
+    width: 80%;
 }
 
 /* Import Roboto font */

--- a/client/src/components/css/AboutUs.css
+++ b/client/src/components/css/AboutUs.css
@@ -9,7 +9,6 @@
     height: 50%;
     border: solid 1px #979797;
     background-color: #222222;
-    /* margin:auto; */
     overflow:hidden;
     text-align:center;
     width: 100%;

--- a/client/src/components/css/Footer.css
+++ b/client/src/components/css/Footer.css
@@ -30,14 +30,14 @@ a {
 }
 
 .left {
-    width: 50%;
+    width: 30%;
     float: left;
     text-align: center;
     padding-left: 10%;
 }
 
 .right {
-    width: 50%;
+    width: 70%;
     float: left;
     text-align: center;
     padding-right: 5%;
@@ -52,7 +52,7 @@ a {
 }
 
 .rectangleBackground > div {
-    display: inline-block;
+    display: flex;
     margin: 2%;
     padding: 20px;
     overflow: hidden;

--- a/client/src/components/css/Spotlight.css
+++ b/client/src/components/css/Spotlight.css
@@ -26,15 +26,15 @@
   width: 160px;
   height: 1px;
   border: solid 2px #fe4349;
-  margin-bottom: 20%;
+  margin-bottom: 30px;
 }
 
 .impact-underline {
-  display: none;
+  display: flex;
   width: 125px;
   height: 1px;
   border: solid 2px #fe4349;
-  margin-bottom: 20%;
+  margin-bottom: 30px;
 }
 
 @import url(https://fonts.googleapis.com/css?family=Roboto);
@@ -54,6 +54,14 @@
 .spotlight-features-container {
   display: flex;
   justify-content: space-around;
+}
+.impact-features-container {
+  display: flex;
+  justify-content: space-around;
+}
+
+.hidden {
+  display: none;
 }
 
 .feature {
@@ -81,7 +89,3 @@
   color: #4a4a4a;
 }
 
-.impact-features-container {
-  display: none;
-  justify-content: space-around;
-}

--- a/client/src/components/css/Spotlight.css
+++ b/client/src/components/css/Spotlight.css
@@ -1,0 +1,87 @@
+.card-container {
+  padding-left: 10%;
+  padding-right: 10%;
+  padding-top: 5%;
+  padding-bottom: 10%;
+}
+
+.titles-container {
+  height: 50%;
+  /* border: solid 1px #979797; */
+  margin:auto;
+  overflow:hidden;
+  text-align:center;
+  width: 100%;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: baseline;
+}
+
+.text-underline-container {
+  align-items: center;
+}
+
+.spotlight-underline {
+  display: flex;
+  width: 160px;
+  height: 1px;
+  border: solid 2px #fe4349;
+  margin-bottom: 20%;
+}
+
+.impact-underline {
+  display: none;
+  width: 125px;
+  height: 1px;
+  border: solid 2px #fe4349;
+  margin-bottom: 20%;
+}
+
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+.title-text {
+  font-family: Roboto;
+  font-size: 40px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #4a4a4a;
+  padding-bottom: 1%;
+  margin: 0%;
+}
+
+.spotlight-features-container {
+  display: flex;
+  justify-content: space-around;
+}
+
+.feature {
+  width: 175px;
+  align-items: center;
+}
+
+.feature-image {
+  width: 100%;
+  height: 175px;
+  background-color: #e4e4e5;
+  border-radius: 50%
+}
+
+.feature-text {
+  padding-top: 5%;
+  text-align: center;
+  font-family: Roboto;
+  font-size: 24px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #4a4a4a;
+}
+
+.impact-features-container {
+  display: none;
+  justify-content: space-around;
+}

--- a/client/src/components/css/Spotlight.css
+++ b/client/src/components/css/Spotlight.css
@@ -26,7 +26,8 @@
   width: 160px;
   height: 1px;
   border: solid 2px #fe4349;
-  margin-bottom: 30px;
+  margin-top: 5px;
+  margin-bottom: 50px;
 }
 
 .impact-underline {
@@ -34,7 +35,8 @@
   width: 125px;
   height: 1px;
   border: solid 2px #fe4349;
-  margin-bottom: 30px;
+  margin-top: 5px;
+  margin-bottom: 50px;
 }
 
 @import url(https://fonts.googleapis.com/css?family=Roboto);

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -4,6 +4,7 @@ import LandingPageHeader from '../components/LandingPageHeader';
 import LandingPageNavbar from './../components/LandingPageNavbar';
 import AboutUs from '../components/AboutUs';
 import Teachers from '../components/Teachers';
+import Spotlight from '../components/Spotlight';
 
 
 /**
@@ -25,6 +26,7 @@ class LandingPage extends Component {
         <LandingPageHeader />
         <LandingPageNavbar />
         <AboutUs />
+        <Spotlight />
         <Teachers />
         <Footer />
       </div>


### PR DESCRIPTION
Added Spotlight/Impact card with BFA logo as placeholder image with dynamically changing containers/underline components. 

Current view:
<img width="1040" alt="Screen Shot 2019-03-16 at 7 41 12 PM" src="https://user-images.githubusercontent.com/32784532/54483587-8ab9d300-4823-11e9-9339-6fc3e069ab80.png">

Mockup:
<img width="712" alt="Screen Shot 2019-03-16 at 7 36 24 PM" src="https://user-images.githubusercontent.com/32784532/54483544-d029d080-4822-11e9-9f62-112a1bdce511.png">



Also fixed the About Us overlapping text bug with different screen sizes. 