### PR TITLE
Remove Package Lock in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+./package-lock.json
+./client/package-lock.json
+./server/package-lock.json
 .DS_Store
 
 # Logs


### PR DESCRIPTION
Fuck up that package-lock.json. 😡🧨
Basically keeping us from making changes to it because Heroku will take care of it when we deploy.