### PR TITLE
Fix landing page route

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,12 +19,12 @@ const App = () => (
   <Provider store={store}>
     <Router>
       <Switch>
-      <Route path="/" component={LandingPage} />
       <Route path="/login" component={Login} />
       <Route path="/makePayment" component={PaymentPortal} />
       <Route path="/paymentPage" component={PaymentPage} />
       <Route path="/events" component={EventsPage} />
       <Route path="/aboutUs" component={AboutUs} />
+      <Route path="/" component={LandingPage} />
       <Route component={NoMatch} />
       </Switch>
     </Router>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,10 +19,10 @@ const App = () => (
   <Provider store={store}>
     <Router>
       <Switch>
+      <Route path="/" component={LandingPage} />
       <Route path="/login" component={Login} />
       <Route path="/makePayment" component={PaymentPortal} />
       <Route path="/paymentPage" component={PaymentPage} />
-      <Route path="/landingPage" component={LandingPage} />
       <Route path="/events" component={EventsPage} />
       <Route path="/aboutUs" component={AboutUs} />
       <Route component={NoMatch} />


### PR DESCRIPTION
Simple fix, now we just go to the landing page with the `/` route. No longer need to do `/landingPage`