### PR TITLE
Fix syntax error

### DIFF
--- a/server/config/email-server.js
+++ b/server/config/email-server.js
@@ -1,4 +1,4 @@
 module.exports = {
-    User: //PUT EMAIL HERE ,
-    Pass: //PUT PASSWORD HERE
+    User: "", //PUT EMAIL HERE 
+    Pass: ""//PUT PASSWORD HERE
 }


### PR DESCRIPTION
Quick fix to make sure prod is still working. 

You might see an error with "invalid credentials"/"missing credentials" on the backend that is to be expected because of the email client not getting any credentials. 

It does not affect anything else in terms of the functioning of the backend.